### PR TITLE
Fix dev server startup under ts-node-dev

### DIFF
--- a/aqw-classic/server/package.json
+++ b/aqw-classic/server/package.json
@@ -2,7 +2,6 @@
   "name": "aqw-classic-server",
   "version": "0.1.0",
   "private": true,
-  "type": "module",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc -p .",

--- a/aqw-classic/server/src/index.ts
+++ b/aqw-classic/server/src/index.ts
@@ -2,7 +2,7 @@ import { createServer } from "http";
 import { Server } from "colyseus";
 import { WebSocketTransport } from "@colyseus/ws-transport";
 import dotenv from "dotenv";
-import GameRoom from "./rooms/GameRoom.js";
+import GameRoom from "./rooms/GameRoom";
 
 dotenv.config();
 

--- a/aqw-classic/server/tsconfig.json
+++ b/aqw-classic/server/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
+    "module": "CommonJS",
     "moduleResolution": "Node",
     "outDir": "dist",
     "rootDir": "src",
@@ -9,6 +9,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "sourceMap": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "types": ["node"]
   },
   "include": ["src"]


### PR DESCRIPTION
## Summary
- switch the server build back to CommonJS so ts-node-dev can load entrypoints without ESM loader errors
- restore the ts-node-dev dev script and adjust the GameRoom import path accordingly
- enable decorator support required by the Colyseus schema definitions

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e384f61ad08332a646e8dbe1b8d054