### PR TITLE
Fix Colyseus room filter configuration

### DIFF
--- a/aqw-classic/server/src/index.ts
+++ b/aqw-classic/server/src/index.ts
@@ -24,7 +24,7 @@ const gameServer = new Server({
   })
 });
 
-gameServer.define("game", GameRoom, { map: "hub" }).filterBy("map");
+gameServer.define("game", GameRoom, { map: "hub" }).filterBy(["map"]);
 
 gameServer.listen(port);
 


### PR DESCRIPTION
## Summary
- adjust the Colyseus room filter to pass an array of metadata fields so matchmaking no longer errors

## Testing
- npm run build --prefix server *(fails: upstream type declaration issues in dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e387e25f848332a029b09f3ad0f91e