### PR TITLE
Fix BootScene asset loading path reset for Phaser 3.90

### DIFF
--- a/aqw-classic/client/src/scenes/BootScene.ts
+++ b/aqw-classic/client/src/scenes/BootScene.ts
@@ -8,6 +8,7 @@ export default class BootScene extends Phaser.Scene {
   }
 
   preload() {
+    const previousPath = this.load.path;
     this.load.setPath(ASSET_BASE_PATH);
     this.load.spritesheet("player", "char.png", {
       frameWidth: 256,
@@ -16,7 +17,7 @@ export default class BootScene extends Phaser.Scene {
     this.load.image("monster", "monster.png");
     this.load.image("drop", "drop.png");
     this.load.image("ground-tile", "ground-tile.png");
-    this.load.resetPath();
+    this.load.setPath(previousPath ?? "");
   }
 
   create() {


### PR DESCRIPTION
## Summary
- store the loader path before setting the asset base path in `BootScene`
- restore the previous loader path instead of calling the removed `resetPath()` helper so Phaser 3.90 can boot

## Testing
- npm --prefix aqw-classic/client run build

------
https://chatgpt.com/codex/tasks/task_e_68e39f7955f083329352e03c90506c06